### PR TITLE
Fixed Spark-Swift Jar inclusion in the "conf/spark-defaults.conf"

### DIFF
--- a/sahara/plugins/spark/config_helper.py
+++ b/sahara/plugins/spark/config_helper.py
@@ -399,7 +399,7 @@ def generate_spark_slaves_configs(workernames):
 def generate_spark_executor_classpath(cluster):
     cp = get_config_value("Spark", "Executor extra classpath", cluster)
     if cp:
-        return "spark.driver.extraClassPath " + cp
+        return "spark.driver.extraClassPath " + cp + "\n" + "spark.executor.extraClassPath " + cp
     return "\n"
 
 


### PR DESCRIPTION
Fixed Spark-Swift Jar inclusion in the "conf/spark-defaults.conf" as extraClassPath for both driver and executors
