### PR TITLE
Fixed Spark History Server launch.

### DIFF
--- a/sahara/plugins/spark/run_scripts.py
+++ b/sahara/plugins/spark/run_scripts.py
@@ -47,6 +47,8 @@ def clean_port_hadoop(nn_remote):
 
 
 def start_spark_history_server(nn_remote, sp_home, eventlog):
+    if eventlog.startsWith("file://"):
+        nn_remote.execute_command("mkdir " + eventlog[7:])
     nn_remote.execute_command("bash " + os.path.join(sp_home,
                                                      "sbin/start-history-server.sh " + eventlog))
 


### PR DESCRIPTION
start_spark_history_server now creates the EventLogDirectory when a local directory is selected.
