### PR TITLE
Now Spark extra configuration options are correctly passed to the Job.

### DIFF
--- a/sahara/plugins/spark/config_helper.py
+++ b/sahara/plugins/spark/config_helper.py
@@ -582,6 +582,7 @@ def set_extra_configuration_properties(master, wf, configuration):
         spark_defaults = os.path.join(wf, "conf/spark-defaults.conf")
         properties_to_add = ""
         for key, value in configuration.iteritems():
-            properties_to_add += key + "=" + value + "\n"
+            if key.startswith("spark"):
+                properties_to_add += key + "=" + value + "\n"
 
         r.execute_command("echo $'" + properties_to_add + "' >> " + spark_defaults)

--- a/sahara/service/edp/spark/engine.py
+++ b/sahara/service/edp/spark/engine.py
@@ -241,12 +241,15 @@ class SparkJobEngine(base_engine.JobEngine):
         port = c_helper.get_config_value("Spark", "Master port", self.cluster)
         spark_home = c_helper.get_config_value("Spark", "Spark home", self.cluster)
 
-        export_spark_conf_dir = ""
-        swift_username = updated_job_configs["configs"].get(sw.HADOOP_SWIFT_USERNAME, None)
-        swift_password = updated_job_configs["configs"].get(sw.HADOOP_SWIFT_PASSWORD, None)
+        export_spark_conf_dir = c_helper.copy_config_folder(master, wf_dir, spark_home)
+
+        swift_username = updated_job_configs["configs"].pop(sw.HADOOP_SWIFT_USERNAME, None)
+        swift_password = updated_job_configs["configs"].pop(sw.HADOOP_SWIFT_PASSWORD, None)
         if swift_username is not None and swift_password is not None:
-            export_spark_conf_dir = sw.configure_swift_credentials_for_spark_on_master(master, wf_dir, spark_home,
+            export_spark_conf_dir = sw.configure_swift_credentials_for_spark_on_master(master, wf_dir,
                                                                                        swift_username, swift_password)
+
+        c_helper.set_extra_configuration_properties(master, wf_dir, updated_job_configs["configs"])
 
         spark_submit = os.path.join(spark_home, "bin/spark-submit")
 

--- a/sahara/service/edp/spark/engine.py
+++ b/sahara/service/edp/spark/engine.py
@@ -246,8 +246,7 @@ class SparkJobEngine(base_engine.JobEngine):
         swift_username = updated_job_configs["configs"].pop(sw.HADOOP_SWIFT_USERNAME, None)
         swift_password = updated_job_configs["configs"].pop(sw.HADOOP_SWIFT_PASSWORD, None)
         if swift_username is not None and swift_password is not None:
-            export_spark_conf_dir = sw.configure_swift_credentials_for_spark_on_master(master, wf_dir,
-                                                                                       swift_username, swift_password)
+            sw.configure_swift_credentials_for_spark_on_master(master, wf_dir, swift_username, swift_password)
 
         c_helper.set_extra_configuration_properties(master, wf_dir, updated_job_configs["configs"])
 

--- a/sahara/swift/swift_helper.py
+++ b/sahara/swift/swift_helper.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -51,7 +51,7 @@ def get_swift_configs():
 
     result = [cfg for cfg in configs if cfg['value']]
     LOG.info(_LI("Swift would be integrated with the following "
-             "params: {result}").format(result=result))
+                 "params: {result}").format(result=result))
     return result
 
 
@@ -59,17 +59,9 @@ def read_default_swift_configs():
     return x.load_hadoop_xml_defaults('swift/resources/conf-template.xml')
 
 
-def configure_swift_credentials_for_spark_on_master(master, wf, spark_home, swift_username, swift_password):
-    # Copy conf/ directory of spark inside job directory
-    org = os.path.join(spark_home, "conf")
-    cp_command = "cp -r " + org + " " + wf
+def configure_swift_credentials_for_spark_on_master(master, wf, swift_username, swift_password):
     with remote.get_remote(master) as r:
-        r.execute_command(cp_command)
         spark_defaults = os.path.join(wf, "conf/spark-defaults.conf")
-        r.execute_command("echo '' >> " + spark_defaults)
-        r.execute_command("echo 'spark.hadoop." + HADOOP_SWIFT_USERNAME + "=" + swift_username + "' >> " +
-                          spark_defaults)
-        r.execute_command("echo 'spark.hadoop." + HADOOP_SWIFT_PASSWORD + "=" + swift_password + "' >> " +
-                          spark_defaults)
-
-    return "export SPARK_CONF_DIR=" + os.path.join(wf, "conf") + ";"
+        properties_to_add = "spark.hadoop." + HADOOP_SWIFT_USERNAME + "=" + swift_username + "\n" + \
+                            "spark.hadoop." + HADOOP_SWIFT_PASSWORD + "=" + swift_password + "\n"
+        r.execute_command("echo $'" + properties_to_add + "' >> " + spark_defaults)


### PR DESCRIPTION
Configuration that belong to spark are passed to the Job. This has been achieved by giving to every SparkJob its own configuration folder and copying the extra configuration option inside spark-defaults.conf file.
