### PR TITLE
Enable Hadoop-Swift Jar to write on hdfs tmp folder

### DIFF
--- a/sahara/plugins/spark/plugin.py
+++ b/sahara/plugins/spark/plugin.py
@@ -311,6 +311,8 @@ class SparkProvider(p.ProvisioningPluginBase):
                         'sudo chmod 755 %(nn_path)s %(dn_path)s' %
                         {"nn_path": nn_path, "dn_path": dn_path})
 
+        add_user_to_hdfs_group = ('sudo adduser $USER hadoop')
+
         with remote.get_remote(instance) as r:
             r.execute_command(
                 'sudo chown -R $USER:$USER /etc/hadoop'
@@ -339,6 +341,7 @@ class SparkProvider(p.ProvisioningPluginBase):
                 r.execute_command(
                     'sudo chmod +x /etc/hadoop/topology.sh'
                 )
+            r.execute_command(add_user_to_hdfs_group)
 
             self._write_topology_data(r, cluster, extra)
             self._push_master_configs(r, cluster, extra, instance)

--- a/sahara/plugins/spark/plugin.py
+++ b/sahara/plugins/spark/plugin.py
@@ -307,11 +307,11 @@ class SparkProvider(p.ProvisioningPluginBase):
         nn_path = os.path.join(hdfs_path, 'nn')
 
         hdfs_dir_cmd = ('sudo mkdir -p %(nn_path)s %(dn_path)s &&'
-                        'sudo chown -R hdfs:hadoop %(nn_path)s %(dn_path)s &&'
-                        'sudo chmod 755 %(nn_path)s %(dn_path)s' %
-                        {"nn_path": nn_path, "dn_path": dn_path})
+                        'sudo chown -R hdfs:hadoop %(hdfs_path)s &&'
+                        'sudo chmod -R 775 %(hdfs_path)s' %
+                        {"nn_path": nn_path, "dn_path": dn_path, "hdfs_path": hdfs_path})
 
-        enable_user_write_hdfs = 'sudo adduser $USER hadoop && sudo chmod -R 775 ' + hdfs_path
+        enable_user_write_hdfs = 'sudo adduser $USER hadoop'
 
         with remote.get_remote(instance) as r:
             r.execute_command(


### PR DESCRIPTION
When Spark use Swift as output file system, use the same 'filesystem' used by Hadoop to write on Swift. This 'filesystem' save tmp files inside the specified (inside Hadoop configuration files) Hadoop tmp folder by using Unix file permission. So we need to give the user that will launch the Job permission to write on that folder.
